### PR TITLE
Add shipping into payment line items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ sandbox/*.sqlite
 /sandbox/whoosh_index/
 /sandbox/emails/
 /sandbox/logs/
+
+# Env
+env

--- a/oscar_stripe_sca/views.py
+++ b/oscar_stripe_sca/views.py
@@ -42,7 +42,8 @@ class StripeSCAPaymentDetailsView(CorePaymentDetailsView):
         stripe_session = Facade().begin(
             customer_email,
             ctx["basket"],
-            ctx["order_total"])
+            ctx["order_total"],
+            ctx["shipping_method"])
         self.request.session["stripe_session_id"] = stripe_session.id
         self.request.session["stripe_payment_intent_id"] = stripe_session.payment_intent
         ctx['stripe_publishable_key'] = settings.STRIPE_PUBLISHABLE_KEY


### PR DESCRIPTION
Checks for `basket.is_shipping_required() and shipping_method` so digital products should be intact. Tested in sandbox and my store. I tried to make minimum changes possible. Happy to accommodate any change requests

Resolves https://github.com/st8st8/django-oscar-stripe-sca/issues/7