### PR TITLE
Add mocking and documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,73 @@ Run the migrations and start the server:
     >python manage.py migrate
     >python manage.py runserver
 
+Testing without a Stripe account
+=================================
+
+``oscar_stripe_sca.testing`` provides drop-in mock views so that your
+integration and feature tests never make real Stripe API calls.
+
+Wiring in the mock config
+--------------------------
+
+Replace the real app config with the mock one in your test settings:
+
+.. code-block:: python
+
+    INSTALLED_APPS[
+        INSTALLED_APPS.index("oscar_stripe_sca.apps.StripeSCACheckoutConfig")
+    ] = "oscar_stripe_sca.apps.MockStripeSCACheckoutConfig"
+
+This must happen before Django's app registry is initialised (i.e. in your settings module).
+
+Controlling accept / cancel per test
+--------------------------------------
+
+The mock payment view reads ``settings.STRIPE_TESTING_OUTCOME`` on every
+request, so you can flip it between test cases without restarting Django.
+
+Add a default in your test settings:
+
+.. code-block:: python
+
+    STRIPE_TESTING_OUTCOME = "accept"  # or "cancel"
+
+**pytest** — use the ``settings`` fixture from ``pytest-django``:
+
+.. code-block:: python
+
+    import pytest
+
+    @pytest.mark.django_db
+    def test_cancel(client, settings):
+        settings.STRIPE_TESTING_OUTCOME = "cancel"
+        # … drive checkout via the test client …
+
+**behave** — override per scenario using tags in ``environment.py``:
+
+.. code-block:: python
+
+    # features/environment.py
+    from django.conf import settings
+
+    def before_scenario(context, scenario):
+        settings.STRIPE_TESTING_OUTCOME = (
+            "cancel" if "payment_cancel" in scenario.tags else "accept"
+        )
+
+Example behave feature test
+-----------------------------
+
+.. code-block:: gherkin
+
+    Scenario: A logged-in user completes a purchase.
+      ...
+       Then I see "Your order has been placed"
+    @payment_cancel
+    Scenario: A logged-in user cancels payment.
+      ...
+       Then I see "Stripe transaction cancelled"
+
 TODO
 ====
  - The tests have not been updated yet.

--- a/oscar_stripe_sca/apps.py
+++ b/oscar_stripe_sca/apps.py
@@ -5,9 +5,9 @@ from django.urls import path
 
 class StripeSCACheckoutConfig(CheckoutConfig):
     def ready(self):
-        stripe_payment_details_view = get_class("oscar_stripe_sca.views", "StripeSCAPaymentDetailsView")
-        stripe_success_view = get_class("oscar_stripe_sca.views", "StripeSCASuccessResponseView")
-        stripe_cancel_view = get_class("oscar_stripe_sca.views", "StripeSCACancelResponseView")
+        self.stripe_payment_details_view = get_class("oscar_stripe_sca.views", "StripeSCAPaymentDetailsView")
+        self.stripe_success_view = get_class("oscar_stripe_sca.views", "StripeSCASuccessResponseView")
+        self.stripe_cancel_view = get_class("oscar_stripe_sca.views", "StripeSCACancelResponseView")
         super().ready()
 
     def get_urls(self):
@@ -22,3 +22,16 @@ class StripeSCACheckoutConfig(CheckoutConfig):
         ]
         return urls
     
+
+class MockStripeSCACheckoutConfig(StripeSCACheckoutConfig):
+    """Checkout app config that wires in mock Stripe views for feature tests."""
+
+    def ready(self):
+        super().ready()
+        from oscar_stripe_sca.testing import (
+            MockStripePaymentDetailsView,
+            MockStripeSuccessResponseView,
+        )
+
+        self.payment_details_view = MockStripePaymentDetailsView
+        self.stripe_success_view = MockStripeSuccessResponseView

--- a/oscar_stripe_sca/apps.py
+++ b/oscar_stripe_sca/apps.py
@@ -24,7 +24,7 @@ class StripeSCACheckoutConfig(CheckoutConfig):
     
 
 class MockStripeSCACheckoutConfig(StripeSCACheckoutConfig):
-    """Checkout app config that wires in mock Stripe views for feature tests."""
+    """Checkout app config that wires in mock Stripe views for tests."""
 
     def ready(self):
         super().ready()

--- a/oscar_stripe_sca/testing.py
+++ b/oscar_stripe_sca/testing.py
@@ -1,20 +1,9 @@
 """Mock Stripe views for feature tests.
 
-Wire these in by swapping the app config in your test settings:
-
-    INSTALLED_APPS[
-        INSTALLED_APPS.index("oscar_stripe_sca.apps.StripeSCACheckoutConfig")
-    ] = "oscar_stripe_sca.testing.MockStripeSCACheckoutConfig"
-
-Control accept/cancel per-scenario in your behave environment.py:
 
     from django.conf import settings
-
-    def before_scenario(context, scenario):
-        if 'payment_cancel' in scenario.tags:
-            settings.STRIPE_TESTING_OUTCOME = 'cancel'
-        else:
-            settings.STRIPE_TESTING_OUTCOME = 'accept'
+    settings.STRIPE_TESTING_OUTCOME = 'cancel'
+    settings.STRIPE_TESTING_OUTCOME = 'accept'
 """
 
 from django.conf import settings as django_settings
@@ -27,7 +16,7 @@ from oscar_stripe_sca.views import StripeSCASuccessResponseView
 
 
 class MockStripePaymentDetailsView(CorePaymentDetailsView):
-    """Replaces the Stripe-hosted payment page during feature tests.
+    """Replaces the Stripe-hosted payment page during tests.
 
     Reads ``settings.STRIPE_TESTING_OUTCOME``:
 

--- a/oscar_stripe_sca/testing.py
+++ b/oscar_stripe_sca/testing.py
@@ -1,0 +1,87 @@
+"""Mock Stripe views for feature tests.
+
+Wire these in by swapping the app config in your test settings:
+
+    INSTALLED_APPS[
+        INSTALLED_APPS.index("oscar_stripe_sca.apps.StripeSCACheckoutConfig")
+    ] = "oscar_stripe_sca.testing.MockStripeSCACheckoutConfig"
+
+Control accept/cancel per-scenario in your behave environment.py:
+
+    from django.conf import settings
+
+    def before_scenario(context, scenario):
+        if 'payment_cancel' in scenario.tags:
+            settings.STRIPE_TESTING_OUTCOME = 'cancel'
+        else:
+            settings.STRIPE_TESTING_OUTCOME = 'accept'
+"""
+
+from django.conf import settings as django_settings
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from oscar.apps.checkout.views import PaymentDetailsView as CorePaymentDetailsView
+
+from oscar_stripe_sca.apps import StripeSCACheckoutConfig
+from oscar_stripe_sca.views import StripeSCASuccessResponseView
+
+
+class MockStripePaymentDetailsView(CorePaymentDetailsView):
+    """Replaces the Stripe-hosted payment page during feature tests.
+
+    Reads ``settings.STRIPE_TESTING_OUTCOME``:
+
+    - ``'accept'`` (default): freezes the basket and redirects to the
+      preview page, exactly as Stripe would after a successful payment.
+    - ``'cancel'``: freezes the basket and redirects to the cancel URL,
+      which thaws it and returns to the basket summary.
+    """
+
+    def get(self, request, *args, **kwargs):
+        outcome = getattr(django_settings, "STRIPE_TESTING_OUTCOME", "accept")
+        basket = request.basket
+
+        # Freeze the basket (the real Stripe facade does this in Facade.begin())
+        basket.freeze()
+
+        # Store fake session keys so handle_payment() can read and delete them.
+        request.session["stripe_session_id"] = "mock-session"
+        request.session["stripe_payment_intent_id"] = "mock-pi"
+
+        if outcome == "cancel":
+            return HttpResponseRedirect(
+                reverse("checkout:stripe-cancel", kwargs={"basket_id": basket.id})
+            )
+
+        # accept: hand off to the preview page, just as Stripe's redirect would.
+        return HttpResponseRedirect(
+            reverse("checkout:stripe-preview", kwargs={"basket_id": basket.id})
+        )
+
+
+class MockIntent:
+    def capture(self):
+        # No-op: skips the real Stripe capture during tests.
+        pass
+
+
+class MockFacade:
+    def retrieve_payment_intent(self, _pi):
+        return MockIntent()
+
+
+class MockStripeSuccessResponseView(StripeSCASuccessResponseView):
+    """Preview / place-order view for tests — skips the real Stripe capture."""
+
+    @property
+    def facade(self):
+        return MockFacade()
+
+
+class MockStripeSCACheckoutConfig(StripeSCACheckoutConfig):
+    """Checkout app config that wires in mock Stripe views for feature tests."""
+
+    def ready(self):
+        super().ready()
+        self.payment_details_view = MockStripePaymentDetailsView
+        self.stripe_success_view = MockStripeSuccessResponseView

--- a/oscar_stripe_sca/views.py
+++ b/oscar_stripe_sca/views.py
@@ -74,9 +74,13 @@ class StripeSCASuccessResponseView(CorePaymentDetailsView):
             ).to_integral_value()
         return ctx
 
+    @property
+    def facade(self):
+        return Facade()
+
     def handle_payment(self, order_number, order_total, **kwargs):
         pi = self.request.session["stripe_payment_intent_id"]
-        intent = Facade().retrieve_payment_intent(pi)
+        intent = self.facade.retrieve_payment_intent(pi)
         intent.capture()
 
         source_type, __ = SourceType.objects.get_or_create(name=PAYMENT_METHOD_STRIPE)


### PR DESCRIPTION
Hi, since I use feature tests, I needed a way to mock the stripe API. This adds the classes and functions to do that for me.

I don't know why master is not up to date and the `self.` was missing ...